### PR TITLE
Add Github Action workflow to validate XML files in pull requests

### DIFF
--- a/.github/workflows/xml-validation.yml
+++ b/.github/workflows/xml-validation.yml
@@ -1,0 +1,31 @@
+name: Validate XML Files
+
+on:
+  pull_request:
+    paths:
+      - '**/*.xml' # Trigger only on .xml files
+
+jobs:
+  validate-xml:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Fetch full history to ensure all commits are available
+
+      - name: Install xmllint
+        run: sudo apt-get update && sudo apt-get install -y libxml2-utils
+
+      - name: Fetch the base branch
+        run: |
+          git fetch origin ${{ github.event.pull_request.base.ref }} # Ensure the base branch is fetched
+
+      - name: Validate XML files
+        run: |
+          # Find and validate all .xml files in the pull request
+          for file in $(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep '\.xml$'); do
+            echo "Validating $file..."
+            xmllint --noout "$file" || exit 1
+          done


### PR DESCRIPTION
Should help prevent any more malformed XML patches from being merged to the main branch accidentally.

This is what it will look like if it detects invalid XML in the pull request:

![image](https://github.com/user-attachments/assets/4a3748e6-193c-473c-8639-53f955f49234)

If you click on the failed action for more details you'll see a summary like this:

![image](https://github.com/user-attachments/assets/1eec4e0a-6bb4-4cb3-b24f-b710796b5611)
