### PR TITLE
Fix xml-validator to handle spaces in file paths

### DIFF
--- a/.github/workflows/xml-validation.yml
+++ b/.github/workflows/xml-validation.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Validate XML files
         run: |
           # Find and validate all .xml files in the pull request
-          for file in $(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep '\.xml$'); do
+          git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep '\.xml$' | while read -r file; do
             echo "Validating $file..."
             xmllint --noout "$file" || exit 1
           done


### PR DESCRIPTION
This pull request includes a small improvement to the XML validation workflow in the `.github/workflows/xml-validation.yml` file. The change updates the loop syntax for better compatibility.

* [`.github/workflows/xml-validation.yml`](diffhunk://#diff-9d57d0a257ffd7d6a7fe6ba4f528b6f8e6257d6b7b41cb2c0e0619f0bd4fc5acL28-R28): Replaced the `for` loop with a `while read` loop to process XML files, improving the handling of filenames with special characters.